### PR TITLE
Grunt should fail when linting fails

### DIFF
--- a/tasks/jslint.js
+++ b/tasks/jslint.js
@@ -58,7 +58,9 @@ function expandAndExclude(grunt, files, excludedFiles) {
   excludedFiles = grunt.file.expand(excludedFiles);
 
   var exclude = {};
-  excludedFiles.forEach(function (e) { exclude[e] = true; });
+  excludedFiles.forEach(function (e) {
+    exclude[e] = true;
+  });
 
   files = grunt.file
     .expand(files)
@@ -134,7 +136,7 @@ gruntJSLint.task = function (grunt, config, next) {
     grunt.log.write(template);
 
     if (report.failures && options.failOnError) {
-      next(false);
+      grunt.fail.fatal('jslint found ' + report.failures + 'failures', code, 3);
     } else {
       next(true);
     }

--- a/tasks/jslint.js
+++ b/tasks/jslint.js
@@ -136,7 +136,7 @@ gruntJSLint.task = function (grunt, config, next) {
     grunt.log.write(template);
 
     if (report.failures && options.failOnError) {
-      grunt.fail.fatal('jslint found ' + report.failures + 'failures', code, 3);
+      grunt.fail.fatal('jslint found ' + report.failures + ' violations', 3);
     } else {
       next(true);
     }


### PR DESCRIPTION
Hi,

we had the Problem that our build agent wasn't notified by grunt when linting  failed.
In the case of linting errors  we let  grunt  fail with an error, so our automated build may  fail when an error occurs. (Of course only when the failOnError option is set ;) )

Hope this change is of use for your project.

Cheers,
Michael
